### PR TITLE
No more reloading

### DIFF
--- a/app/models/concerns/flexible_metadata/dynamic_metadata_behavior.rb
+++ b/app/models/concerns/flexible_metadata/dynamic_metadata_behavior.rb
@@ -7,10 +7,69 @@ module FlexibleMetadata
 
     included do
       # Dynamically set up the metadata properties
-      FlexibleMetadata::DynamicSchemaService.model_properties(work_class_name: self.to_s).each_pair do |prop, value|
-        property prop, predicate: value[:predicate], multiple: value[:multiple]
-      end
       type(FlexibleMetadata::DynamicSchemaService.rdf_type(work_class_name: self.to_s))
+    end
+
+    class_methods do
+      # It appears to be safe to add w/o removing first
+      # Index blocks are not supported here
+      def late_add_property(name, properties)
+        raise ArgumentError, "You must provide a `:predicate' option to property" unless properties.key?(:predicate)
+        # Logic stolen from ActiveFedora property class method
+        properties = { multiple: true }.merge(properties)
+        # always recreate the delegated attributes class in case of property changes
+        delegated_attributes[name] = ActiveFedora::ActiveTripleAttribute.new(name, properties)
+        reflection = ActiveFedora::Attributes::PropertyBuilder.build(self, name, properties)
+        ActiveTriples::Reflection.add_reflection self, name, reflection
+        # stolen from GeneragedResourceSchmeStrategy to clear out the generaged resource class being out of sync
+        if @generated_resource_class
+          @generated_resource_class.property name, properties
+        end
+        true
+      end
+
+      # name - string name of property
+      # TODO - we are not using this right now, but its a good start to something hard to figure out
+      def late_remove_property(name)
+        name_string = name.to_s
+        # remove from delegated_attributes
+        self.delegated_attributes = self.delegated_attributes.except(name)
+        # Remove from ActiveTriples reflections
+        self.properties = self.properties.except(name)
+      end
+    end
+
+    # Override ActiveFedora::Core 11.5.5 to include flexible metadata load
+    def initialize(attributes = nil, &_block)
+      init_internals
+      attributes = attributes.dup if attributes # can't dup nil in Ruby 2.3
+      id = attributes && (attributes.delete(:id) || attributes.delete('id'))
+      @ldp_source = build_ldp_resource(id)
+      raise IllegalOperation, "Attempting to recreate existing ldp_source: `#{ldp_source.subject}'" unless ldp_source.new?
+      load_flexible_metadata ## This is the new part
+      assign_attributes(attributes) if attributes
+      assert_content_model
+      load_attached_files
+
+      yield self if block_given?
+      _run_initialize_callbacks
+    end
+
+    # Override ActiveFedora::Core 11.5.5 to include flexible metadata load
+    def init_with_resource(rdf_resource)
+      init_internals
+      @ldp_source = rdf_resource
+      load_flexible_metadata  ## This is the new part
+      load_attached_files
+      run_callbacks :find
+      run_callbacks :initialize
+      self
+    end
+
+    def load_flexible_metadata
+      FlexibleMetadata::DynamicSchemaService.model_properties(work_class_name: self.class.to_s).each do |prop, value|
+        self.class.late_add_property prop, predicate: value[:predicate], multiple: value[:multiple]
+      end
     end
 
     # Retrieve the dynamic schema

--- a/app/models/concerns/flexible_metadata/dynamic_metadata_behavior.rb
+++ b/app/models/concerns/flexible_metadata/dynamic_metadata_behavior.rb
@@ -5,11 +5,6 @@ module FlexibleMetadata
   module DynamicMetadataBehavior
     extend ActiveSupport::Concern
 
-    included do
-      # Dynamically set up the metadata properties
-      type(FlexibleMetadata::DynamicSchemaService.rdf_type(work_class_name: self.to_s))
-    end
-
     class_methods do
       # It appears to be safe to add w/o removing first
       # Index blocks are not supported here
@@ -70,6 +65,7 @@ module FlexibleMetadata
       FlexibleMetadata::DynamicSchemaService.model_properties(work_class_name: self.class.to_s).each do |prop, value|
         self.class.late_add_property prop, predicate: value[:predicate], multiple: value[:multiple]
       end
+      self.class.type(FlexibleMetadata::DynamicSchemaService.rdf_type(work_class_name: self.class.to_s))
     end
 
     # Retrieve the dynamic schema

--- a/app/services/flexible_metadata/flexible_metadata_constructor.rb
+++ b/app/services/flexible_metadata/flexible_metadata_constructor.rb
@@ -26,9 +26,6 @@ module FlexibleMetadata
       profile.save!
       logger.info(%(LoadedFlexibleMetadata::Profile ID=#{profile.id}))
       create_dynamic_schemas(profile: profile)
-      # @todo - this is not the right way to do this, and won't work across multiple servers
-      #  and it may well cause other problems
-      reload_models(profile: profile)
       profile
     end
 
@@ -101,13 +98,6 @@ module FlexibleMetadata
     #       end.inject(:merge)
     #   }
     # end
-
-    def self.reload_models(profile:)
-      profile.classes.each do |cl|
-        Object.send(:remove_const, cl.name) if Object.const_defined?(:Image)
-        load "app/models/#{cl.name.underscore}.rb"
-      end
-    end
 
     private
 


### PR DESCRIPTION
In this commit we remove the loading of dynamic properties from when the class loads entirely. Which means our ActiveFedora models run around as propertyless as a non-white non-male in the 1600s. Then right as we are loading the data from Fedora we load the properties in to the class, giving us what we need to utialize said properties w/o having to reload whole classes dynamically. 

This _should_ set us up in a good spot for versioning in the future, though care will need to be taken to sort out what happens when multiple instances of the same class in different versions of the scheme exists in memory at the same time.